### PR TITLE
fixed get /user/me return error

### DIFF
--- a/app/db/alembic/versions/30db74217de5_modify_position_upgrade_function.py
+++ b/app/db/alembic/versions/30db74217de5_modify_position_upgrade_function.py
@@ -1,0 +1,47 @@
+"""modify position upgrade function
+
+Revision ID: 30db74217de5
+Revises: d35415c31651
+Create Date: 2023-11-18 20:46:01.920281
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# import sqlalchemy as sa
+from sqlalchemy import Table, MetaData
+
+# revision identifiers, used by Alembic.
+revision: str = "30db74217de5"
+down_revision: Union[str, None] = "d35415c31651"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    data = [
+        {"seq": 1, "name": "GK"},
+        {"seq": 2, "name": "RB"},
+        {"seq": 3, "name": "RWB"},
+        {"seq": 4, "name": "CB"},
+        {"seq": 5, "name": "LB"},
+        {"seq": 6, "name": "LWB"},
+        {"seq": 7, "name": "CDM"},
+        {"seq": 8, "name": "RM"},
+        {"seq": 9, "name": "CM"},
+        {"seq": 10, "name": "LM"},
+        {"seq": 11, "name": "CAM"},
+        {"seq": 12, "name": "RW"},
+        {"seq": 13, "name": "ST"},
+        {"seq": 14, "name": "LW"},
+        {"seq": 15, "name": "CF"},
+    ]
+
+    metadata = MetaData()
+    position_table = Table("position", metadata, autoload_with=op.get_bind())
+    op.bulk_insert(position_table, data)
+
+
+def downgrade() -> None:
+    pass

--- a/app/rest_api/schema/profile.py
+++ b/app/rest_api/schema/profile.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 from pydantic import BaseModel, Field, StrictInt, StrictStr
 
@@ -12,6 +12,6 @@ class UpdateProfileSchema(BaseModel):
 
 class GetProfileSchema(BaseModel):
     nickname: StrictStr = Field(title="닉네임", default=None)
-    img: str = Field(title="이미지 URL", default=None)
+    img: Union[str, None] = Field(title="이미지 URL", default=None)
     sex: str = Field(title="성별", default="M")
     join_profile: List[JoinPositionSchema] = []


### PR DESCRIPTION
fixed GET /user/me return error:
fastapi.exceptions.ResponseValidationError: 1 validation errors:
  {'type': 'string_type', 'loc': ('response', 'profile', 0, 'img'), 'msg': 'Input should be a valid string', 'input': None, 'url': 'https://errors.pydantic.dev/2.2/v/string_type'}

error occurred because img required str as return type but received null
 
img now requires Union[str, None] as return type