### PR TITLE
club, guest, match modification

### DIFF
--- a/app/db/alembic/versions/255977718c41_remove_clubs_columns_in_profile_table.py
+++ b/app/db/alembic/versions/255977718c41_remove_clubs_columns_in_profile_table.py
@@ -1,0 +1,30 @@
+"""remove clubs columns in profile table
+
+Revision ID: 255977718c41
+Revises: 17c8e176960f
+Create Date: 2024-07-27 18:04:32.985927
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "255977718c41"
+down_revision: Union[str, None] = "17c8e176960f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column("users", "clubs")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("clubs", sa.ARRAY(sa.Integer), nullable=True, comment="클럽"),
+    )

--- a/app/model/club.py
+++ b/app/model/club.py
@@ -24,7 +24,13 @@ class Club(Base):
     uniform_color = Column(String(24), comment="유니폼 색")
     deleted = Column(Boolean, default=False, comment="삭제 여부")
 
-    members = relationship("User", secondary="join_club", back_populates="clubs")
+    members = relationship(
+        "User",
+        secondary="join_club",
+        primaryjoin="and_(Club.seq == JoinClub.clubs_seq, JoinClub.accepted == True)",
+        secondaryjoin="and_(User.seq == JoinClub.user_seq, User.is_active == True)",
+        back_populates="clubs",
+    )
 
     poll = relationship("Poll", back_populates="club")
     home_matches = relationship(

--- a/app/model/user.py
+++ b/app/model/user.py
@@ -31,7 +31,13 @@ class User(Base):
 
     profile = relationship(Profile, back_populates="user", cascade="all, delete-orphan")
 
-    clubs = relationship("Club", secondary="join_club", back_populates="members")
+    clubs = relationship(
+        "Club",
+        secondary="join_club",
+        primaryjoin="and_(User.seq == JoinClub.user_seq, JoinClub.accepted == True)",
+        secondaryjoin="and_(Club.seq == JoinClub.clubs_seq, Club.deleted == False)",
+        back_populates="members",
+    )
 
     join_club_posting = relationship(
         JoinClubPosting, back_populates="user", cascade="all, delete-orphan"

--- a/app/rest_api/api/guest/guest.py
+++ b/app/rest_api/api/guest/guest.py
@@ -155,7 +155,15 @@ def filter_guests(
     per_page: int = Query(10, title="페이지당 수", ge=1, le=100),
     db: Session = Depends(get_db),
 ):
-    query = db.query(Guest).filter(Guest.closed == False)
+    today = datetime.today()
+    query = db.query.join(Match, Guest.match_seq == Match.seq)
+    query = (
+        db.query(Guest)
+        .join(Match, Guest.match_seq == Match.seq)
+        .filter(
+            Guest.closed == False, Match.matched == False, Match.match_date >= today
+        )
+    )
     query = guest_filter.filter(query)
     offset = (page - 1) * per_page
     query = query.limit(per_page).offset(offset)

--- a/app/rest_api/schema/club/club.py
+++ b/app/rest_api/schema/club/club.py
@@ -36,7 +36,7 @@ class UpdateClubSchema(BaseModel):
 class FilterClubSchema(Filter):
     seq__in: list[int] | None = Field(None, title="시퀸스 리스트")
     name__ilike: str | None = Field(None, title="이름")
-    location__in: list[str] | None = Field(None, title="장소 리스트")
+    location__ilike: str | None = Field(None, title="장소 리스트")
     age_group__in: list[str] | None = Field(None, title="연령대 리스트")
     level__in: list[int] | None = Field(None, title="실력 리스트")
     gender__in: list[Literal["M", "F", "U"]] | None = Field(None, title="성별")

--- a/app/rest_api/schema/match/match.py
+++ b/app/rest_api/schema/match/match.py
@@ -44,7 +44,8 @@ class FilterMatchSchema(Filter):
     home_club_seq__in: list[int] | None = Field(None, title="홈 클럽 시퀸스")
     away_club_seq__in: list[int] | None = Field(None, title="원정 클럽 시퀸스")
     match_type__in: list[str] | None = Field(None, title="매치 유형")
-    location__in: list[str] | None = Field(None, title="장소 리스트")
+    location__ilike: str | None = Field(None, title="장소 리스트")
+    match_date: dt.date | None = Field(None, title="매치 날짜")
     match_date__gte: dt.date | None = Field(None, title="최소 매치 날짜")
     match_date__lte: dt.date | None = Field(None, title="최대 매치 날짜")
     start_time__gte: dt.time | None = Field(None, title="최소 매치시간")
@@ -54,8 +55,12 @@ class FilterMatchSchema(Filter):
     gender__in: list[Literal["M", "F", "U"]] | None = Field(None, title="성별")
     match_fee__gte: int | None = Field(None, title="최소 회비")
     match_fee__lte: int | None = Field(None, title="최대 회비")
-    home_club_guest_seq__in: list[int] | None = Field(None, title="홈 클럽 용별 게시글 시퀸스")
-    away_club_guest_seq__in: list[int] | None = Field(None, title="원정 클럽용별 게시글 시퀸스")
+    home_club_guest_seq__in: list[int] | None = Field(
+        None, title="홈 클럽 용별 게시글 시퀸스"
+    )
+    away_club_guest_seq__in: list[int] | None = Field(
+        None, title="원정 클럽용별 게시글 시퀸스"
+    )
 
     class Constants(Filter.Constants):
         model = Match


### PR DESCRIPTION
fixed club, guest, match bugs

GET /user/match_history 삭제된 클럽이 존재시 club:null로 리턴됨

GET /user/match_schedule, GET /user/posting 등 클럽과 연관된 엔드포인트 확인하기

PATCH /club/{club_seq}/join 클럽 가입 신청 엔드포인트 확인하기 - 클럽수락없이 userInfo에 해당 클럽정보가 생김 

PATCH /club/{club_seq}/accept 클럽 가입 수락 엔드포인트 확인하기 - 주장이 아님에도 불구하고 클럽 가입 수락이 호출됨 

경기지역 필터 수정하기 → like로

경기날짜 지정 필터

날짜가 지난 용병 게시물이 보여지는거 수정하기